### PR TITLE
Add Jest testing for admonitions script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "codebook",
+  "version": "1.0.0",
+  "description": "Testing setup for admonitions script",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/tests/admonitions.test.js
+++ b/tests/admonitions.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const script = fs.readFileSync(path.join(__dirname, '../assets/admonitions.js'), 'utf8');
+
+function run(html) {
+  const dom = new JSDOM(html, { runScripts: 'outside-only' });
+  const fn = new dom.window.Function(script);
+  fn();
+  return dom;
+}
+
+describe('admonitions script', () => {
+  const types = ['note', 'tip', 'important', 'warning', 'caution', 'error', 'success'];
+  const labels = ['Note', 'Tip', 'Important', 'Warning', 'Caution', 'Error', 'Success'];
+
+  test('inserts icons and classes for each admonition type', () => {
+    const html = `\n<div class="markdown-body">\n  ${types.map(t => `<blockquote>[!${t.toUpperCase()}] ${t}</blockquote>`).join('\n  ')}\n</div>`;
+    const dom = run(html);
+    const { document } = dom.window;
+    const blocks = document.querySelectorAll('blockquote');
+    types.forEach((type, i) => {
+      const block = blocks[i];
+      expect(block.classList.contains('markdown-alert')).toBe(true);
+      expect(block.classList.contains(`markdown-alert-${type}`)).toBe(true);
+      expect(block.innerHTML).toContain(`<strong>${labels[i]}:</strong>`);
+      expect(block.textContent).not.toMatch(/\[!.*\]/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add npm config for jest and jsdom
- create unit test for assets/admonitions.js

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683fef72596c832d8216885bee8a97db