### PR TITLE
Fix small typo

### DIFF
--- a/Guides/Install-WordPress-Apache-Debian-ISPConfig.md
+++ b/Guides/Install-WordPress-Apache-Debian-ISPConfig.md
@@ -28,7 +28,7 @@ apt update && apt upgrade -y
 <br>
 
 ## Step 3: Set up the site
-Using your ISPConfig 3 control panel, go ahead an add the domain you want to use under:
+Using your ISPConfig 3 control panel, go ahead and add the domain you want to use under:
 
 > Sites >>> Websites >>> Website >>> Add new website
 


### PR DESCRIPTION
## Summary
- fix a typo in the ISPConfig WordPress guide

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_683ff0917cd4832d8601469dba248113