### PR TITLE
Fix empty string path in apps-script

### DIFF
--- a/apps-script/openai/chat-completions.md
+++ b/apps-script/openai/chat-completions.md
@@ -191,8 +191,8 @@ function runChatRow(promptRangeA1, outputRangeA1, model,
   const prompts = sheet.getRange(promptRangeA1).getValues()[0];
 
   const replies = [prompts.map(p =>
-    p ? callOpenAI(p, model, temperature) : '')
-  ];
+    p ? callOpenAI(p, model, temperature) : ''
+  )];
 
   sheet.getRange(outputRangeA1).offset(0, 0, 1, replies[0].length)
        .setValues(replies);


### PR DESCRIPTION
## Summary
- fix the return path for `runChatRow` so the empty string value is correct

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ff2444628832d93498c31788f3771