### PR TITLE
Add copy button reset test

### DIFF
--- a/assets/copy-code-blocks.js
+++ b/assets/copy-code-blocks.js
@@ -12,8 +12,11 @@ document.querySelectorAll('pre > code').forEach((codeBlock) => {
 
   button.addEventListener('click', () => {
     navigator.clipboard.writeText(codeBlock.innerText).then(() => {
+      const originalText = button.innerText;
       button.innerText = 'Copied!';
-      setTimeout(() => button.innerText = 'Copy', 2000);
+      setTimeout(() => {
+        button.innerText = originalText;
+      }, 2000);
     });
   });
 });

--- a/tests/copy-code-blocks.test.js
+++ b/tests/copy-code-blocks.test.js
@@ -30,4 +30,22 @@ describe('copy-code-blocks script', () => {
 
     expect(button.innerText).toBe('Copied!');
   });
+
+  test('button text resets after timeout', async () => {
+    jest.useFakeTimers();
+    const html = '<pre><code>console.log("test");</code></pre>';
+    const dom = run(html);
+    const button = dom.window.document.querySelector('pre button');
+
+    // Click and wait for clipboard Promise to resolve
+    button.dispatchEvent(new dom.window.Event('click'));
+    await Promise.resolve();
+    expect(button.innerText).toBe('Copied!');
+
+    // Advance timers and ensure text resets
+    jest.advanceTimersByTime(2000);
+    await Promise.resolve();
+    expect(button.innerText).toBe('⿻');
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure copy button reverts to original text
- verify reset behavior in new Jest test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683ff4854c00832da291dbba48cc7547