### PR TITLE
Add documentation layout with navigation

### DIFF
--- a/Guides/Install-WordPress-Apache-Debian-ISPConfig.html
+++ b/Guides/Install-WordPress-Apache-Debian-ISPConfig.html
@@ -1,27 +1,6 @@
 ---
-layout: null
+layout: docs
 permalink: /Guides/Install-WordPress
 ---
-
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- 1. Official GitHub Markdown CSS -->
-    <link rel="stylesheet" href="{{ '/assets/github-markdown.css' | relative_url }}">
-  </head>
-  <body>
-    <!-- 2. Wrap in markdown-body for GitHub styling -->
-    <article class="markdown-body">
-      {% capture md %}{% include_relative Install-WordPress-Apache-Debian-ISPConfig.md %}{% endcapture %}
-      {{ md | markdownify }}
-    </article>
-  </body>
-  
-<script src="/assets/copy-code-blocks.js"></script> 
-<script src="/assets/admonitions.js"></script>
-  
-</html>
-
-
+{% capture md %}{% include_relative Install-WordPress-Apache-Debian-ISPConfig.md %}{% endcapture %}
+{{ md | markdownify }}

--- a/Guides/Postfix-ISPConfig-Mail-Server-2FA-OTP-Emails-Not-Arriving.html
+++ b/Guides/Postfix-ISPConfig-Mail-Server-2FA-OTP-Emails-Not-Arriving.html
@@ -1,0 +1,6 @@
+---
+layout: docs
+permalink: /Guides/Postfix-ISPConfig-Mail-Server-2FA-OTP-Emails-Not-Arriving
+---
+{% capture md %}{% include_relative Postfix-ISPConfig-Mail-Server-2FA-OTP-Emails-Not-Arriving.md %}{% endcapture %}
+{{ md | markdownify }}

--- a/Prompts/Template.html
+++ b/Prompts/Template.html
@@ -1,23 +1,6 @@
 ---
-layout: null
+layout: docs
 permalink: /Prompts
 ---
-
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/assets/github-markdown.css">
-  </head>
-  <body>
-    <article class="markdown-body">
-      {% capture md %}{% include_relative AI-Coding-Assistance.md %}{% endcapture %}
-      {{ md | markdownify }}
-    </article>
-    
-<script src="/assets/copy-code-blocks.js"></script> 
-<script src="/assets/admonitions.js"></script>
-
-  </body>
-</html>
+{% capture md %}{% include_relative AI-Coding-Assistance.md %}{% endcapture %}
+{{ md | markdownify }}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ '/assets/github-markdown.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
+  </head>
+  <body>
+    <header class="site-header">
+      <h1><a href="{{ '/' | relative_url }}">Sherafy Codebook</a></h1>
+    </header>
+    <div class="container">
+      <aside class="sidebar">
+        <ul>
+          <li class="category">Wordpress
+            <ul>
+              <li><a href="{{ '/wordpress/post-sync.html' | relative_url }}">Post Sync</a></li>
+            </ul>
+          </li>
+          <li class="category">Python
+            <ul>
+              <li><a href="{{ '/python/pdf-generator.html' | relative_url }}">Pdf Generator</a></li>
+            </ul>
+          </li>
+          <li class="category">Prompts
+            <ul>
+              <li><a href="{{ '/Prompts/Template.html' | relative_url }}">Ai Coding Assistance</a></li>
+            </ul>
+          </li>
+          <li class="category">Guides
+            <ul>
+              <li><a href="{{ '/Guides/Install-WordPress-Apache-Debian-ISPConfig.html' | relative_url }}">Install WordPress Apache Debian Ispconfig</a></li>
+              <li><a href="{{ '/Guides/Postfix-ISPConfig-Mail-Server-2FA-OTP-Emails-Not-Arriving.html' | relative_url }}">Postfix Ispconfig Mail Server 2fa Otp Emails Not Arriving</a></li>
+            </ul>
+          </li>
+          <li class="category">Apps Script
+            <ul>
+              <li><a href="{{ '/apps-script/git-pages.html' | relative_url }}">Git Pages</a></li>
+              <li><a href="{{ '/apps-script/openai/chat-completions.html' | relative_url }}">Chat Completions</a></li>
+            </ul>
+          </li>
+          <li class="category">Ssh Bash
+            <ul>
+              <li><a href="{{ '/ssh-bash/access-github-via-ssh.html' | relative_url }}">Access Github Via Ssh</a></li>
+            </ul>
+          </li>
+        </ul>
+      </aside>
+      <main class="markdown-body">
+        {{ content }}
+      </main>
+    </div>
+    <script src="{{ '/assets/copy-code-blocks.js' | relative_url }}"></script>
+    <script src="{{ '/assets/admonitions.js' | relative_url }}"></script>
+  </body>
+</html>

--- a/apps-script/git-pages.html
+++ b/apps-script/git-pages.html
@@ -1,0 +1,6 @@
+---
+layout: docs
+permalink: /apps-script/git-pages
+---
+{% capture md %}{% include_relative git-pages.md %}{% endcapture %}
+{{ md | markdownify }}

--- a/apps-script/openai/chat-completions.html
+++ b/apps-script/openai/chat-completions.html
@@ -1,0 +1,6 @@
+---
+layout: docs
+permalink: /apps-script/openai/chat-completions
+---
+{% capture md %}{% include_relative chat-completions.md %}{% endcapture %}
+{{ md | markdownify }}

--- a/assets/main.css
+++ b/assets/main.css
@@ -1,0 +1,57 @@
+body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.container {
+  display: flex;
+  flex: 1;
+}
+
+.site-header {
+  background: #151b23;
+  color: #f0f6fc;
+  padding: 1rem;
+  text-align: center;
+  border-bottom: 1px solid #3d444d;
+}
+
+.site-header a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.sidebar {
+  width: 220px;
+  background: #0d1117;
+  border-right: 1px solid #3d444d;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.sidebar li {
+  margin-bottom: 0.5rem;
+}
+
+.sidebar a {
+  color: #58a6ff;
+  text-decoration: none;
+}
+
+.sidebar .category {
+  margin-top: 1rem;
+  font-weight: 600;
+  color: #c9d1d9;
+}
+
+.markdown-body {
+  padding: 2rem;
+  flex: 1;
+}

--- a/index.html
+++ b/index.html
@@ -1,24 +1,6 @@
 ---
-layout: null
+layout: docs
 permalink: /
 ---
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- 1. Official GitHub Markdown CSS -->
-    <link rel="stylesheet" href="/assets/github-markdown.css">
-  </head>
-  <body>
-    <!-- 2. Wrap in markdown-body for GitHub styling -->
-    <article class="markdown-body">
-      {% capture md %}{% include_relative README.md %}{% endcapture %}
-      {{ md | markdownify }}
-    </article>
-  </body>
-  
-<script src="/assets/copy-code-blocks.js"></script> 
-<script src="/assets/admonitions.js"></script>
-  
-</html>
+{% capture md %}{% include_relative README.md %}{% endcapture %}
+{{ md | markdownify }}

--- a/python/pdf-generator.html
+++ b/python/pdf-generator.html
@@ -1,0 +1,6 @@
+---
+layout: docs
+permalink: /python/pdf-generator
+---
+{% capture md %}{% include_relative pdf-generator.md %}{% endcapture %}
+{{ md | markdownify }}

--- a/ssh-bash/access-github-via-ssh.html
+++ b/ssh-bash/access-github-via-ssh.html
@@ -1,0 +1,6 @@
+---
+layout: docs
+permalink: /ssh-bash/access-github-via-ssh
+---
+{% capture md %}{% include_relative access-github-via-ssh.md %}{% endcapture %}
+{{ md | markdownify }}

--- a/wordpress/post-sync.html
+++ b/wordpress/post-sync.html
@@ -1,0 +1,6 @@
+---
+layout: docs
+permalink: /wordpress/post-sync
+---
+{% capture md %}{% include_relative post-sync.md %}{% endcapture %}
+{{ md | markdownify }}


### PR DESCRIPTION
## Summary
- create `docs` layout with header and sidebar
- add site styling in `assets/main.css`
- convert existing pages to use new layout
- add HTML wrappers for markdown files

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683ff7cc3e0c832d947728fcf8560d17