### PR TITLE
Fix dynamic menu filter for Jekyll 3

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -15,7 +15,10 @@
         <ul>
           {% assign directories = "wordpress,python,prompts,guides,apps-script,ssh-bash" | split: ',' %}
           {% for dir in directories %}
-            {% assign pages = site.html_pages | where_exp: 'p', "p.path contains dir and p.path != 'index.html'" | sort: 'permalink' %}
+          {% assign pages = site.html_pages
+             | where_exp: 'p', "p.path contains dir"
+             | where_exp: 'p', "p.path != 'index.html'"
+             | sort: 'permalink' %}
             {% if pages != empty %}
               <li class="category">{{ dir | replace: '-', ' ' | capitalize }}
                 <ul>


### PR DESCRIPTION
## Summary
- update docs layout to avoid complex `where_exp` expression that caused Liquid syntax error

## Testing
- `jekyll build --trace`

------
https://chatgpt.com/codex/tasks/task_b_6840019f6154832d9ccd6ba8fcb6823a